### PR TITLE
ログイン状態によりヘッダーの表示を分岐

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,12 +1,17 @@
 <div class="navbar bg-primary w-full h-[80px] px-[40px]">
     <div class="flex items-center justify-between w-full h-full">
-      <%= link_to "Bean Trip", root_path, class: "text-base-100 text-4xl font-heading font-bold" %>
-      <div class="text-base-100 text-base font-bold font-body space-x-[40px]">
+      <%= link_to "Bean Trip", root_path, class: "flex-none text-base-100 text-4xl font-heading font-bold mr-[40px]" %>
+      <div class="flex-none text-base-100 text-base font-bold font-body space-x-[40px]">
         <%= link_to "豆診断", "#" %>
         <%= link_to "豆検索・豆投稿", "#" %>
         <%= link_to "店舗検索", "#" %>
-        <%= link_to "新規登録", new_user_registration_path %>
-        <%= link_to "ログイン", new_user_session_path %>
+        <% if user_signed_in? %>
+          <%= link_to "マイページ", "#" %>
+          <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+        <% else %>
+          <%= link_to "新規登録", new_user_registration_path %>
+          <%= link_to "ログイン", new_user_session_path %>
+        <% end %>
       </div>
     </div>
 </div>


### PR DESCRIPTION
close #18 

## 概要
- ログイン状態により、ヘッダーの表示が分岐するように変更した
- 未ログインの場合は、新規登録とログインのボタンが表示される
- ログイン済の場合は、マイページとログアウトのボタンが表示される

## 実施したタスク
- [x] `app/views/shared/_header.html.erb`を編集する
- [x] ログイン状態に応じて、ヘッダーの表示を分岐させる