### PR TITLE
countryモデル、countriesテーブルの作成

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,0 +1,3 @@
+class Country < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20250504164114_create_countries.rb
+++ b/db/migrate/20250504164114_create_countries.rb
@@ -1,0 +1,9 @@
+class CreateCountries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :countries do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_04_154147) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_04_164114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "countries", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "stores", force: :cascade do |t|
     t.string "place_id", null: false

--- a/test/fixtures/countries.yml
+++ b/test/fixtures/countries.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/country_test.rb
+++ b/test/models/country_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CountryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #26 

## 概要
- コーヒー豆の生産国情報を管理する`country`モデル、`countries`テーブルを作成した

## 実施したタスク
- [x] `docker compose exec web bin/rails g model country`を実行する
- [x] ER図を参考にして、`countries`テーブルを作成するためのマイグレーションファイルを編集する
- [x] `docker compose exec web bin/rails db:migrate`を実行する
- [x] `app/models/country.rb`を編集する