### PR TITLE
Google Maps PlatformのAPIキーの設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+# '/'（ルートディレクトリ）下の環境変数管理ファイルをGitの追跡対象から除外
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'rails-i18n', '~> 7.0.0'
 # 'devise'を多言語化するためのgemをインストール
 gem 'devise-i18n'
 
+# 環境変数を管理するgem 'dotenv-rails'をインストール
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,10 @@ GEM
     devise-i18n (1.13.0)
       devise (>= 4.9.0)
       rails-i18n
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
     faker (3.5.1)
@@ -348,6 +352,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  dotenv-rails
   faker
   jbuilder
   jsbundling-rails


### PR DESCRIPTION
close #28 

## 概要
- Google Maps PlatformのAPIキーを環境変数として追加した

## 実施したタスク
- [x] Google Cloud コンソールにて、APIキーの作成と設定をする
- [x] `Gemfile`に`gem 'dotenv-rails'`を追記する
- [x] `docker compose run web bundle install`を実行する
- [x] `.gitignore`ファイルに`/ .env`を追記し、環境変数管理ファイルがGitにより管理されないようにする
- [x] `$ touch .env`を実行する
- [x] `.env`ファイルに`GOOGLE_MAPS_API_KEY = "作成したAPIキー"`を記述する
- [x] `Render.com`にAPIキーを環境変数として追加する