### PR TITLE
画像投稿以外の新規投稿機能の実装

### DIFF
--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -13,17 +13,25 @@ class BeansController < ApplicationController
   def create
     # 複数のモデルに対する操作を行うので、transactionメソッドを使用
     ActiveRecord::Base.transaction do
-      # フォームから受け取ったパラメータの内、':country'は除外
+      # フォームから受け取ったパラメータの内、':country'、':store'、':place_id'は除外
       # それ以外のパラメータを引数として、Beanモデルのインスタンスをビルド
-      @bean = current_user.beans.build(bean_params.except(:country))
+      @bean = current_user.beans.build(bean_params.except(:country, :store, :place_id))
 
       # countriesテーブルにて、国名が一致するレコードがあれば取得し、なければ作成
       country = Country.find_or_create_by!(name: bean_params[:country])
       # 取得もしくは生成したCountryモデルのインスタンスを、Beanモデルのインスタンスに関連付ける
       @bean.country = country
-      @bean.store = nil
 
-      if @bean.save
+      # storesテーブルにて、フォームから送られてきた'place_id'と一致するレコードがあれば取得し、なければ作成
+      store = Store.find_by(place_id: bean_params[:place_id])
+
+      if store.nil?
+        store = Store.create!(get_place_detail_data(bean_params[:place_id]))
+      end
+
+      @bean.store = store
+
+      if @bean.save!
         redirect_to beans_path, notice: t('beans.create.success')
       else
         flash.now[:alert] = t('beans.create.failure')
@@ -32,7 +40,7 @@ class BeansController < ApplicationController
     end
 
   rescue ActiveRecord::RecordInvalid => e
-    flash.now[:alert] = "#{t('beans.create.failure')}: #{e.message}"
+    flash.now[:alert] = "#{t('beans.create.failure')}\n #{e.message}"
     render :new, status: :unprocessable_entity
   end
 
@@ -44,6 +52,57 @@ class BeansController < ApplicationController
 
   # ストロングパラメータ
   def bean_params
-    params.require(:bean).permit(:name, :country, :area, :farm, :roast_level, :blended, :bitterness, :sweetness, :acidity, :body, :aroma, :comment)
+    params.require(:bean).permit(:name, :country, :area, :farm, :roast_level, :blended, :store, :place_id, :bitterness, :sweetness, :acidity, :body, :aroma, :comment)
+  end
+
+  # 'place id'を元にPlaces APIを叩いて、場所の詳細情報を取得するメソッド
+  def get_place_detail_data(place_id)
+    require 'open-uri'
+    require 'json'
+
+    # クエリパラメータの作成
+    request_query = URI.encode_www_form(
+      place_id: place_id,
+      language: 'ja',
+      key: ENV['GOOGLE_MAPS_API_KEY']
+    )
+
+    # リクエスト用のURLを生成
+    request_url = "https://maps.googleapis.com/maps/api/place/details/json?#{request_query}"
+    # APIを叩いてJSON形式でデータを取得
+    place_detail_json_data = URI.open(request_url).read
+    # JSON形式のデータをRubyオブジェクトに変換
+    place_detail_data = JSON.parse(place_detail_json_data)
+
+    # DBのカラム名と同じキーを持つハッシュを生成し、それを使用して取得した場所データをDBに保存
+    result = {}
+    # place id
+    result[:place_id] = place_detail_data['result']['place_id']
+    # 場所の名前
+    result[:name] = place_detail_data['result']['name']
+    # 郵便番号
+    result[:post_code] = place_detail_data['result']['address_components'].find { |c| c['types'].include?('postal_code') }&.fetch('long_name', nil)
+
+    # 国名付きの住所を取得
+    full_address = place_detail_data['result']['formatted_address']
+    # 国名の部分を削除
+    result[:address] = full_address.sub(/\A[^ ]+ ?/, '')
+
+    # 電話番号
+    result[:phone_number] = place_detail_data['result']['formatted_phone_number']
+    # 営業時間
+    result[:opening_hours] = place_detail_data['result']['opening_hours']['weekday_text'].join("\n") if place_detail_data['result']['opening_hours'].present?
+    # WebサイトのURL
+    result[:web_site_url] = place_detail_data['result']['website']
+    # Googleのレビュー点数
+    result[:rating] = place_detail_data['result']['rating']
+    # 画像
+    result[:image] = place_detail_data['result']['photos'].first['photo_reference'] if place_detail_data['result']['photos'].present?
+    # 緯度・経度
+    result[:latitude] = place_detail_data['result']['geometry']['location']['lat']
+    result[:longitude] = place_detail_data['result']['geometry']['location']['lng']
+
+    # 生成したハッシュを返す
+    result
   end
 end

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -1,11 +1,49 @@
 class BeansController < ApplicationController
+  # indexアクションとshowアクション以外は、ログインを必須にする
+  before_action :authenticate_user!, only: %i[new create]
+
   def index
     @beans = Bean.includes(:user)
   end
 
-  def new; end
+  def new
+    @bean = Bean.new
+  end
+
+  def create
+    # 複数のモデルに対する操作を行うので、transactionメソッドを使用
+    ActiveRecord::Base.transaction do
+      # フォームから受け取ったパラメータの内、':country'は除外
+      # それ以外のパラメータを引数として、Beanモデルのインスタンスをビルド
+      @bean = current_user.beans.build(bean_params.except(:country))
+
+      # countriesテーブルにて、国名が一致するレコードがあれば取得し、なければ作成
+      country = Country.find_or_create_by!(name: bean_params[:country])
+      # 取得もしくは生成したCountryモデルのインスタンスを、Beanモデルのインスタンスに関連付ける
+      @bean.country = country
+      @bean.store = nil
+
+      if @bean.save
+        redirect_to beans_path, notice: t('beans.create.success')
+      else
+        flash.now[:alert] = t('beans.create.failure')
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+  rescue ActiveRecord::RecordInvalid => e
+    flash.now[:alert] = "#{t('beans.create.failure')}: #{e.message}"
+    render :new, status: :unprocessable_entity
+  end
 
   def show; end
 
   def edit; end
+
+  private
+
+  # ストロングパラメータ
+  def bean_params
+    params.require(:bean).permit(:name, :country, :area, :farm, :roast_level, :blended, :bitterness, :sweetness, :acidity, :body, :aroma, :comment)
+  end
 end

--- a/app/models/bean.rb
+++ b/app/models/bean.rb
@@ -6,5 +6,6 @@ class Bean < ApplicationRecord
 
   belongs_to :user
   belongs_to :country
-  belongs_to :store
+  # Storeモデルに関連付いたカラムは空値を許容したいので、'optional: true'とする
+  belongs_to :store, optional: true
 end

--- a/app/views/beans/index.html.erb
+++ b/app/views/beans/index.html.erb
@@ -1,7 +1,8 @@
 <div class="flex flex-col items-center w-[1000px] mx-auto">
   <div class="w-full text-black">
     <div class="mt-[50px] text-right">
-      <%= link_to t('.to_new_post'), new_bean_path, class: "btn btn-warning w-[200px] h-[50px]" %>
+      <!-- 遷移先のJSイベントを発火させるためにTurboは無効化 -->
+      <%= link_to t('.to_new_post'), new_bean_path, data: { turbo: false }, class: "btn btn-warning w-[200px] h-[50px]" %>
     </div>
     <h2 class="text-center text-4xl font-bold font-heading mt-[50px]"><%= t('.title') %></h2>
 

--- a/app/views/beans/index.html.erb
+++ b/app/views/beans/index.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col items-center w-[1000px] mx-auto">
   <div class="w-full text-black">
     <div class="mt-[50px] text-right">
-      <%= link_to t('.to_new_post'), "#", class: "btn btn-warning w-[200px] h-[50px]" %>
+      <%= link_to t('.to_new_post'), new_bean_path, class: "btn btn-warning w-[200px] h-[50px]" %>
     </div>
     <h2 class="text-center text-4xl font-bold font-heading mt-[50px]"><%= t('.title') %></h2>
 

--- a/app/views/beans/new.html.erb
+++ b/app/views/beans/new.html.erb
@@ -118,4 +118,6 @@
 </script>
 
 <!-- Place Autocompleteを使用するためのライブラリを読み込む -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&libraries=places&callback=initAutocomplete"></script>
+<script
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&libraries=places&callback=initAutocomplete">
+</script>

--- a/app/views/beans/new.html.erb
+++ b/app/views/beans/new.html.erb
@@ -16,8 +16,9 @@
 
       <!-- 生産国の入力欄 -->
       <div class="form-control text-left text-base font-body mb-[40px]">
-        <%= f.label :country, "生産国名", class: "label w-full font-bold" %>
-        <%= f.text_field :country, autofocus: true, class: "input input-bordered input-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.country') %>
+        <%= f.label :country, t('.label.country'), class: "label w-full font-bold" %>
+        <!-- @bean.countryが存在すれば、それをフィールドの初期値とする -->
+        <%= f.text_field :country, autofocus: true, value: "", class: "input input-bordered input-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.country') %>
       </div>
 
       <div class="flex font-body mb-[40px] space-x-[20px]">
@@ -44,6 +45,14 @@
           <%= f.label :blended, "ブレンド or ストレート", class: "label w-full font-bold" %>
           <%= f.select :blended, options_for_select([["ブレンド", true], ["ストレート", false]]), { include_blank: t('.placeholder.blended') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
         </div>
+      </div>
+
+      <!-- 購入店舗情報の入力欄 -->
+      <div class="form-control text-left text-base font-body mt-[50px] mb-[40px]">
+        <%= f.label :store, t('.label.store'), class: "label w-full font-bold" %>
+        <%= f.text_field :store, id: "Store", autofocus: true, autocomplete: "off", class: "input input-bordered input-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.store') %>
+        <!-- 'hidden_field'で店舗の'place_id'を送信 -->
+        <%= f.hidden_field :place_id, id: "PlaceId" %>
       </div>
 
       <!-- 味バランスの選択欄（後々レーティング形式に移行する） -->
@@ -81,3 +90,32 @@
     </div>
   </div>
 </div>
+
+<!-- 店舗情報入力フィールドに、Places APIを使用したオートコンプリート機能を追加するためのJS -->
+<script>
+  function initAutocomplete () {
+    document.addEventListener('DOMContentLoaded', function () {
+      const inputStore = document.getElementById('Store');
+      const inputPlaceId = document.getElementById('PlaceId');
+
+      // オートコンプリートのオプション
+      const options = {
+        types: ['establishment'],
+        componentRestrictions: { country: 'JP' }
+      };
+
+      // オートコンプリート適用
+      const autocompleteStore = new google.maps.places.Autocomplete(inputStore, options);
+
+      // 店舗情報入力フィールドに変更が加えられた時
+      autocompleteStore.addListener('place_changed', function() {
+        const place = autocompleteStore.getPlace();
+        inputStore.value = place.name;
+        inputPlaceId.value = place.place_id
+      });
+    });
+  }
+</script>
+
+<!-- Place Autocompleteを使用するためのライブラリを読み込む -->
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&libraries=places&callback=initAutocomplete"></script>

--- a/app/views/beans/new.html.erb
+++ b/app/views/beans/new.html.erb
@@ -1,4 +1,83 @@
-<div>
-  <h1 class="font-bold text-4xl">Beans#new</h1>
-  <p>Find me in app/views/beans/new.html.erb</p>
+<div class="flex flex-col items-center w-[700px] mx-auto my-[100px]">
+  <div class="w-full text-black">
+    <div class="text-center font-bold space-y-[10px]">
+      <h2 class="text-4xl font-heading"><%= t('.title') %></h2>
+      <p class="text-base font-body"><%= t('.description') %></p>
+    </div>
+
+    <%= form_with model: @bean, local: true do |f| %>
+      <%= render "shared/error_messages", object: @bean %>
+
+      <!-- 銘柄の入力欄 -->
+      <div class="form-control text-left text-base font-body mt-[50px] mb-[40px]">
+        <%= f.label :name, class: "label w-full font-bold" %>
+        <%= f.text_field :name, autofocus: true, class: "input input-bordered input-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.name') %>
+      </div>
+
+      <!-- 生産国の入力欄 -->
+      <div class="form-control text-left text-base font-body mb-[40px]">
+        <%= f.label :country, "生産国名", class: "label w-full font-bold" %>
+        <%= f.text_field :country, autofocus: true, class: "input input-bordered input-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.country') %>
+      </div>
+
+      <div class="flex font-body mb-[40px] space-x-[20px]">
+        <!-- 生産地区の入力欄 -->
+        <div class="form-control w-1/2 text-left text-base font-body">
+          <%= f.label :area, class: "label w-full font-bold" %>
+          <%= f.text_field :area, autofocus: true, class: "input input-bordered input-primary form-control w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.area') %>
+        </div>
+
+        <!-- 生産農園の入力欄 -->
+        <div class="form-control w-1/2 text-left text-base font-body">
+          <%= f.label :farm, class: "label w-full font-bold" %>
+          <%= f.text_field :farm, autofocus: true, class: "input input-bordered input-primary form-control w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.farm') %>
+        </div>
+      </div>
+
+      <!-- 焙煎度とブレンドorストレートの選択欄 -->
+      <div class="flex font-body mb-[40px] space-x-[20px]">
+        <div class="form-control w-1/2 text-left text-base font-body">
+          <%= f.label :roast_level, class: "label w-full font-bold" %>
+          <%= f.select :roast_level, options_for_select([["浅煎り", 1], ["中煎り", 2], ["深煎り", 3]]), { include_blank: t('.placeholder.roast_level') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
+        </div>
+        <div class="form-control w-1/2 text-left text-base font-body">
+          <%= f.label :blended, "ブレンド or ストレート", class: "label w-full font-bold" %>
+          <%= f.select :blended, options_for_select([["ブレンド", true], ["ストレート", false]]), { include_blank: t('.placeholder.blended') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
+        </div>
+      </div>
+
+      <!-- 味バランスの選択欄（後々レーティング形式に移行する） -->
+      <div class="text-left font-body mb-[40px]">
+        <p class="label font-bold"><%= t('.taste_balance') %></p>
+
+        <!-- 1行、5列で表示 -->
+        <div class="columns-5">
+          <% ["bitterness", "sweetness", "acidity", "body", "aroma"].each do |attr| %>
+            <%= f.label attr.to_sym, class: "label w-full font-bold" %>
+            <!-- 1~5の整数値をドロップダウンリストから選択 -->
+            <%= f.select attr.to_sym,
+                options_for_select([["1（弱め）", 1], ["2", 2], ["3（中程度）", 3], ["4", 4], ["5（強め）", 5]]),
+                { include_blank: t('.placeholder.taste_balance') },
+                class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px] text-xs" %>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- コメント入力欄 -->
+      <div class="form-control text-left text-base font-body mb-[50px]">
+        <%= f.label :comment, class: "label w-full font-bold" %>
+        <%= f.text_area :comment, autofocus: true, class: "textarea textarea-bordered textarea-primary w-full h-[200px] bg-white border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.comment') %>
+      </div>
+
+      <!-- 新規投稿ボタン -->
+      <div class="actions text-center w-full mb-[50px]">
+        <%= f.submit t('.submit'), class: "btn btn-warning w-[200px] h-[50px]" %>
+      </div>
+    <% end %>
+
+    <!-- 豆一覧へ戻るボタン -->
+    <div class="text-center w-full">
+      <%= link_to t('.back_to_bean_index'), beans_path, class: "btn btn-primary w-[200px] h-[50px]" %>
+    </div>
+  </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,7 +3,7 @@ ja:
     models:
       user: ユーザー
       country: 生産国
-      store: 店舗
+      store: 購入店舗
       bean: コーヒー豆
     attributes:
       user:
@@ -27,9 +27,9 @@ ja:
         latitude: 緯度
         longitude: 経度
       bean:
-        name: 銘柄
-        area: 生産地区
-        farm: 生産農園
+        name: 銘柄（品名）
+        area: 生産地区名
+        farm: 生産農園名
         roast_level: 焙煎度
         blended: ブレンド or ストレート
         bitterness: 苦味

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,3 +23,24 @@ ja:
     index:
       title: 豆一覧
       to_new_post: 新規投稿
+    new:
+      title: 豆新規投稿
+      description: 〜 お気に入りのコーヒー豆を投稿できます 〜
+      taste_balance: 味バランス
+      label:
+        country: 生産国名
+        store: 購入店舗
+      placeholder:
+        name: 銘柄を入力（必須）
+        country: 国名を入力（必須）
+        area: 地区名を入力（任意）
+        farm: 農園名を入力（任意）
+        roast_level: 焙煎度を選択（任意）
+        blended: どちらかを選択（任意）
+        taste_balance: 数値を選択（任意）
+        comment: コメントを入力（必須）
+      submit: 新規投稿
+      back_to_bean_index: 一覧へ戻る
+    create:
+      success: 投稿が完了しました
+      failure: 投稿に失敗しました

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,13 +29,14 @@ ja:
       taste_balance: 味バランス
       label:
         country: 生産国名
-        store: 購入店舗
+        store: 購入店舗名
       placeholder:
         name: 銘柄を入力（必須）
         country: 国名を入力（必須）
         area: 地区名を入力（任意）
         farm: 農園名を入力（任意）
         roast_level: 焙煎度を選択（任意）
+        store: 購入店舗名を入力（任意）
         blended: どちらかを選択（任意）
         taste_balance: 数値を選択（任意）
         comment: コメントを入力（必須）

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
   # 豆診断機能へのルーティング
   resources :diagnoses, only: %i[new create show]
 
-  # 豆投稿機能へのルーティング
-  resources :beans, only: %i[index]
+  # 豆検索・豆投稿機能へのルーティング
+  resources :beans, only: %i[index new create]
 
   # 'devise'の各種コントローラへのルーティング
   devise_for :users,


### PR DESCRIPTION
close #29
close #63

## 概要
- 画像投稿以外の新規投稿機能を実装した

## 実施したタスク
- [x] `app/controllers/beans_controller.rb`の`new`アクションを編集する
- [x] `app/controllers/beans_controller.rb`に`create`アクションを編集する
- [x] `app/views/beans/new.html.erb`を編集する
- [x] 店舗情報の入力フィールドについては、Place Autocompleteによるオートコンプリート入力ができるように設定する
- [x] `app/views/beans/index.html.erb`を編集し、新規投稿ページへのリンクを作成する
- [x] `i18n`によるビューの日本語化