### PR TITLE
豆投稿機能の本番環境ストレージにAmazon S3を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'carrierwave', '~> 2.0'
 # 画像の加工機能を実装できる gem 'MiniMagick'をインストール
 gem 'mini_magick'
 
+# CarrierWaveと連携してAmazon S3にファイルをアップロードするためのgem 'fog-aws'をインストール
+gem 'fog-aws'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
+    excon (1.2.5)
+      logger
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.2-aarch64-linux-gnu)
@@ -136,6 +138,23 @@ GEM
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
+    fog-aws (3.31.0)
+      base64 (~> 0.2.0)
+      fog-core (~> 2.6)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.6.0)
+      builder
+      excon (~> 1.0)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.5)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -168,12 +187,17 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0507)
     mini_magick (5.2.0)
       benchmark
       logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_json (1.15.0)
     net-imap (0.5.6)
       date
       net-protocol
@@ -381,6 +405,7 @@ DEPENDENCIES
   devise-i18n
   dotenv-rails
   faker
+  fog-aws
   jbuilder
   jsbundling-rails
   mini_magick

--- a/app/uploaders/bean_image_uploader.rb
+++ b/app/uploaders/bean_image_uploader.rb
@@ -7,8 +7,12 @@ class BeanImageUploader < CarrierWave::Uploader::Base
 
   # Choose what kind of storage to use for this uploader:
   # ローカルストレージを使うなら、'storage :file'を選択
-  storage :file
-  # storage :fog
+  # 本番環境ではAWS S3を使用し、それ以外ではローカルストレージを使用
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.production?
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = ENV['S3_BUCKET_NAME']
+    config.fog_public = false
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
+      region: ENV['S3_REGION'],
+      path_style: true
+    }
+  else
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
+end


### PR DESCRIPTION
close #32 

## 概要
- 豆投稿機能の本番環境では、画像をAmazon S3のバケットに保存するように設定した

## 実施したタスク
- [x] AWSにて、IAMユーザーを作成する
- [x] AWSのコンソール画面から、S3のバケットを作成する
- [x] `Gemfile`に`gem 'fog-aws'`を追記する
- [x] `docker compose run web bundle install`を実行する
- [x] `.env`ファイルにS3へのアクセスキー、シークレットアクセスキー、リージョン、バケット名を環境変数として設定
- [x] `config/initializers/carrierwave.rb`を作成し、編集する
- [x] CarrierWaveのアップローダークラスを編集し、本番環境ではS3を、それ以外ではローカルを利用するように設定する
- [x] Render.comにて、ローカルの`.env`ファイルと同じようにS3へのアクセスキー、シークレットアクセスキー、リージョン、バケット名を環境変数として設定