### PR TITLE
beanモデルのカラム修正

### DIFF
--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -60,7 +60,7 @@ class BeansController < ApplicationController
       :area,
       :farm,
       :roast_level,
-      :blended,
+      :is_blended,
       :store,
       :place_id,
       :image,

--- a/app/views/beans/new.html.erb
+++ b/app/views/beans/new.html.erb
@@ -42,8 +42,8 @@
           <%= f.select :roast_level, options_for_select([["浅煎り", 1], ["中煎り", 2], ["深煎り", 3]]), { include_blank: t('.placeholder.roast_level') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
         </div>
         <div class="form-control w-1/2 text-left text-base font-body">
-          <%= f.label :blended, "ブレンド or ストレート", class: "label w-full font-bold" %>
-          <%= f.select :blended, options_for_select([["ブレンド", true], ["ストレート", false]]), { include_blank: t('.placeholder.blended') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
+          <%= f.label :is_blended, class: "label w-full font-bold" %>
+          <%= f.select :is_blended, options_for_select([["ブレンド", true], ["ストレート", false]]), { include_blank: t('.placeholder.is_blended') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
         </div>
       </div>
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -31,7 +31,7 @@ ja:
         area: 生産地区名
         farm: 生産農園名
         roast_level: 焙煎度
-        blended: ブレンド or ストレート
+        is_blended: ブレンド or ストレート
         bitterness: 苦味
         sweetness: 甘味
         acidity: 酸味

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -37,7 +37,7 @@ ja:
         farm: 農園名を入力（任意）
         roast_level: 焙煎度を選択（任意）
         store: 購入店舗名を入力（任意）
-        blended: どちらかを選択（任意）
+        is_blended: どちらかを選択（任意）
         taste_balance: 数値を選択（任意）
         comment: コメントを入力（必須）
       submit: 新規投稿

--- a/db/migrate/20250505064548_create_beans.rb
+++ b/db/migrate/20250505064548_create_beans.rb
@@ -4,8 +4,8 @@ class CreateBeans < ActiveRecord::Migration[7.2]
       t.string :name, null: false
       t.string :area
       t.string :farm
-      t.integer :roast_level
-      t.boolean :blended
+      t.integer :roast_level, null: false, default: 0
+      t.boolean :is_blended, null: false, default: false
       t.integer :bitterness
       t.integer :sweetness
       t.integer :acidity

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,8 +18,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_05_064548) do
     t.string "name", null: false
     t.string "area"
     t.string "farm"
-    t.integer "roast_level"
-    t.boolean "blended"
+    t.integer "roast_level", default: 0, null: false
+    t.boolean "is_blended", default: false, null: false
     t.integer "bitterness"
     t.integer "sweetness"
     t.integer "acidity"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,7 +62,7 @@ store_ids = Store.ids
     area: Faker::Address.city,
     farm: "#{Faker::Name.last_name}農園",
     roast_level: rand(1..3),
-    blended: [true, false].sample,
+    is_blended: [true, false].sample,
     bitterness: rand(1..5),
     sweetness: rand(1..5),
     acidity: rand(1..5),


### PR DESCRIPTION
close #70 

## 概要
- `beans`テーブルを作成したマイグレーションファイルをロールバックし、以下のようにカラムを修正した
- カラム修正に伴い、ビューやコントローラ等も修正した

```
# 変更前
t.integer :roast_level
t.boolean :blended
```
```
# 変更後
t.integer :roast_level, null: false, default: 0
t.boolean :is_blended, null: false, default: false
```

## 実施したタスク
- [x] `docker compose exec web bin/rails db:rollback`を実行し、`beans`テーブル作成用のマイグレーションファイルを差し戻す
- [x] 差し戻したマイグレーションファイルを修正する
- [x] `docker compose exec web bin/rails db:migrate`を実行し、テーブルを修正する
- [x] ビューやコントローラもカラム名の変更に対応させる
- [x] `Render.com`のデータベースも同じように修正する