### PR TITLE
Feature/add enum to bean model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'mini_magick'
 # CarrierWaveと連携してAmazon S3にファイルをアップロードするためのgem 'fog-aws'をインストール
 gem 'fog-aws'
 
+# enumを多言語化させるためのgemをインストール
+gem 'enum_help'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.1)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.13.1)
     excon (1.2.5)
       logger
@@ -404,6 +406,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  enum_help
   faker
   fog-aws
   jbuilder

--- a/app/models/bean.rb
+++ b/app/models/bean.rb
@@ -4,6 +4,10 @@ class Bean < ApplicationRecord
   validates :farm, length: { maximum: 255 }
   validates :comment, presence: true, length: { maximum: 65_535 }
 
+  # 'roast_level'と'is_blended'カラムにenumを設定し、かつ範囲外の値を保存できないようにバリデーションを設定
+  enum :roast_level, { not_selected: 0, light_roast: 1, medium_roast: 2, dark_roast: 3 }, validate: true
+  enum :is_blended, { blend: true, straight: false }, validate: true
+
   belongs_to :user
   belongs_to :country
   # Storeモデルに関連付いたカラムは空値を許容したいので、'optional: true'とする

--- a/app/views/beans/_bean.html.erb
+++ b/app/views/beans/_bean.html.erb
@@ -10,8 +10,12 @@
       <%= bean.name %>
     </h4>
     <div class="space-y-[5px] text-left text-xs">
-      <p class="truncate">産地：<%= bean.country.name %></p>
-      <p class="truncate">焙煎度：<%= bean.roast_level %></p>
+      <p class="truncate">
+        <%= Country.human_attribute_name(:name) %>：<%= bean.country.name %>
+      </p>
+      <p class="truncate">
+        <%= Bean.human_attribute_name(:roast_level) %>：<%= bean.roast_level_i18n %>
+      </p>
       <p class="line-clamp-2"><%= bean.comment %></p>
     </div>
 

--- a/app/views/beans/new.html.erb
+++ b/app/views/beans/new.html.erb
@@ -39,11 +39,11 @@
       <div class="flex font-body mb-[40px] space-x-[20px]">
         <div class="form-control w-1/2 text-left text-base font-body">
           <%= f.label :roast_level, class: "label w-full font-bold" %>
-          <%= f.select :roast_level, options_for_select([["浅煎り", 1], ["中煎り", 2], ["深煎り", 3]]), { include_blank: t('.placeholder.roast_level') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
+          <%= f.select :roast_level, Bean.roast_levels_i18n.invert, {}, { class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" } %>
         </div>
         <div class="form-control w-1/2 text-left text-base font-body">
           <%= f.label :is_blended, class: "label w-full font-bold" %>
-          <%= f.select :is_blended, options_for_select([["ブレンド", true], ["ストレート", false]]), { include_blank: t('.placeholder.is_blended') }, class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" %>
+          <%= f.select :is_blended, Bean.is_blendeds_i18n.invert, {}, { class: "select select-bordered select-primary w-full h-[50px] bg-white border-[3px] border-primary rounded-[10px]" } %>
         </div>
       </div>
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -39,5 +39,17 @@ ja:
         aroma: 香り
         image: 画像
         comment: コメント
-        created_at: 作成日
-        updated_at: 更新日
+  attributes:
+    id: ID
+    created_at: 作成日時
+    updated_at: 更新日時
+  enums:
+    bean:
+      roast_level:
+        not_selected: 未選択
+        light_roast: 浅煎り
+        medium_roast: 中煎り
+        dark_roast: 深煎り
+      is_blended:
+        blend: ブレンド
+        straight: ストレート

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,15 +29,13 @@ ja:
       taste_balance: 味バランス
       label:
         country: 生産国名
-        store: 購入店舗名
+        store: 購入店舗名（オートコンプリート機能を使用して入力してください）
       placeholder:
         name: 銘柄を入力（必須）
         country: 国名を入力（必須）
         area: 地区名を入力（任意）
         farm: 農園名を入力（任意）
-        roast_level: 焙煎度を選択（任意）
         store: 購入店舗名を入力（任意）
-        is_blended: どちらかを選択（任意）
         taste_balance: 数値を選択（任意）
         comment: コメントを入力（必須）
       submit: 新規投稿


### PR DESCRIPTION
close #71 

## 概要
- `Bean`モデルの`roast_level`カラムと`is_blended`カラムに`enum`を導入した
- `gem 'enum_help'`を導入して、`enum`を`i18n`化した

## 実施したタスク
- [x] `app/models/bean.rb`に以下を追記する
```
enum :roast_level, { not_selected: 0, light_roast: 1, medium_roast: 2, dark_roast: 3 }, validate: true
enum :is_blended, { blend: true, straight: false }, validate: true
```
- [x] `gem 'enum_help'`を導入し、`i18n`化する
- [x] `config/locales/activerecord/ja.yml`を編集する
- [x] ビューを編集する