### PR TITLE
豆削除機能の実装

### DIFF
--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -102,6 +102,12 @@ class BeansController < ApplicationController
     render :edit, status: :unprocessable_entity
   end
 
+  def destroy
+    bean = current_user.beans.find(params[:id])
+    bean.destroy!
+    redirect_to beans_path, notice: t('beans.destroy.success'), status: :see_other
+  end
+
   private
 
   # ストロングパラメータ

--- a/app/views/beans/_bean.html.erb
+++ b/app/views/beans/_bean.html.erb
@@ -40,7 +40,7 @@
             <%= link_to edit_bean_path(bean), data: { turbo: false } do %>
               <i class="fa-solid fa-pen-to-square"></i>
             <% end %>
-            <%= link_to "#" do %>
+            <%= link_to bean_path(bean), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
               <i class="fa-solid fa-trash"></i>
             <% end %>
           </div>

--- a/app/views/beans/show.html.erb
+++ b/app/views/beans/show.html.erb
@@ -9,7 +9,7 @@
           <%= link_to edit_bean_path(@bean), data: { turbo: false } do %>
             <i class="fa-solid fa-pen-to-square"></i>
           <% end %>
-          <%= link_to "#" do %>
+          <%= link_to bean_path(@bean), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
             <i class="fa-solid fa-trash"></i>
           <% end %>
         </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,8 @@ ja:
     submit:
       create: 新規投稿
       update: 更新する
+  defaults:
+    delete_confirm: 削除してもよろしいですか？
   diagnoses:
     new:
       title: 豆診断
@@ -46,6 +48,8 @@ ja:
     update:
       success: 更新が完了しました
       failure: 更新に失敗しました
+    destroy:
+      success: 削除が完了しました
     form:
       label:
         country: 生産国名

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :diagnoses, only: %i[new create show]
 
   # 豆検索・豆投稿機能へのルーティング
-  resources :beans, only: %i[index new create show edit update]
+  resources :beans, only: %i[index new create show edit update destroy]
 
   # 'devise'の各種コントローラへのルーティング
   devise_for :users,


### PR DESCRIPTION
close #35 

## 概要
- 豆削除機能を実装した

## 実施したタスク
- [x] `config/routes.rb`を編集し、`destroy`アクションへのルーティングを設定する
- [x] `app/contollers/beans_controller.rb`に`destory`アクションを追記する
- [x] 以下のビューを編集し、削除機能へのリンクを設定する
  - `app/views/beans/_bean.html.erb`
  - `app/views/beans/show.html.erb`
- [x] `i18n`によるビューの日本語化