### PR TITLE
豆検索機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'fog-aws'
 # enumを多言語化させるためのgemをインストール
 gem 'enum_help'
 
+# 検索機能を実装するためのgemをインストール
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -417,6 +421,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.2)
   rails-i18n (~> 7.0.0)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/beans_controller.rb
+++ b/app/controllers/beans_controller.rb
@@ -3,7 +3,17 @@ class BeansController < ApplicationController
   before_action :authenticate_user!, only: %i[new create edit update]
 
   def index
-    @beans = Bean.includes(:user, :country)
+    # 検索パラメータのroast_levelの値が'未選択'の場合は、それをパラメータから除外し検索をかける
+    if params[:q].present? && (params[:q][:roast_level_eq] == Bean.roast_levels["not_selected"].to_s)
+      params[:q].delete(:roast_level_eq)
+      # Ransackの検索オブジェクトを生成
+      @q = Bean.ransack(params[:q])
+      # 検索オブジェクトから検索結果を重複なしで取得
+      @beans = @q.result(distinct: true).includes(:user, :country).order(created_at: :desc)
+    else
+      @q = Bean.ransack(params[:q])
+      @beans = @q.result(distinct: true).includes(:user, :country).order(created_at: :desc)
+    end
   end
 
   def new

--- a/app/models/bean.rb
+++ b/app/models/bean.rb
@@ -15,4 +15,15 @@ class Bean < ApplicationRecord
 
   # imageカラムにCarrierWaveの'BeanImageUploader'をマウント
   mount_uploader :image, BeanImageUploader
+
+  # Ransackが検索可能なカラムを設定
+  def self.ransackable_attributes(auth_object = nil)
+    # カラム名を配列形式で指定
+    ["name", "comment", "roast_level"]
+  end
+
+  # Ransackが検索可能なアソシエーションを設定
+  def self.ransackable_associations(auth_object = nil)
+    ["country", "user"]
+  end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -2,4 +2,9 @@ class Country < ApplicationRecord
   validates :name, presence: true, uniqueness: true, length: { maximum: 255 }
 
   has_many :beans
+
+  # Ransackが検索可能なカラムを設定
+  def self.ransackable_attributes(auth_object = nil)
+    ["name"]
+  end
 end

--- a/app/views/beans/_search_form.html.erb
+++ b/app/views/beans/_search_form.html.erb
@@ -1,0 +1,16 @@
+<!-- Ransackを使用した検索フォーム -->
+<%= search_form_for q, url: url do |f| %>
+  <div class="flex flex-row justify-center items-center space-x-[20px] w-full h-[50px]">
+    <!-- 銘柄・コメント・生産国に対する検索フィールド（曖昧検索） -->
+    <div class="form-control">
+      <%= f.search_field :name_or_comment_or_country_name_cont, class: "input input-bordered input-primary form-control bg-white w-[400px] border-[3px] border-primary rounded-[10px]", placeholder: t('.placeholder.name_comment_country_name') %>
+    </div>
+
+    <!-- 焙煎度のドロップダウンリスト（完全一致検索） -->
+    <div class="form-control">
+      <%= f.select :roast_level_eq, Bean.roast_levels_i18n.invert.map { |key, value| [key, Bean.roast_levels[value]] }, {}, class: "select select-bordered select-primary bg-white w-[200px] border-[3px] border-primary rounded-[10px]" %>
+    </div>
+
+    <%= f.submit t('defaults.search'), class: "btn btn-accent w-[100px]" %>
+  </div>
+<% end %>

--- a/app/views/beans/index.html.erb
+++ b/app/views/beans/index.html.erb
@@ -4,23 +4,10 @@
       <!-- 遷移先のJSイベントを発火させるためにTurboは無効化 -->
       <%= link_to t('.to_new_post'), new_bean_path, data: { turbo: false }, class: "btn btn-warning w-[200px] h-[50px]" %>
     </div>
-    <h2 class="text-center text-4xl font-bold font-heading mt-[50px]"><%= t('.title') %></h2>
+    <h2 class="text-center text-4xl font-bold font-heading my-[50px]"><%= t('.title') %></h2>
 
-    <!-- 検索フォームのブロック -->
-    <div class="flex flex-row justify-center space-x-[20px] mt-[50px] w-full h-[50px]">
-      <input
-        type="text"
-        placeholder="銘柄、産地で探す"
-        class="input input-bordered input-primary form-control bg-white w-[400px] border-[3px] border-primary rounded-[10px]"
-      />
-      <select class="select select-bordered select-primary bg-white w-[200px] border-[3px] border-primary rounded-[10px]">
-        <option disabled selected>焙煎度を選択</option>
-        <option>浅煎り</option>
-        <option>中煎り</option>
-        <option>深煎り</option>
-      </select>
-      <button class="btn btn-accent w-[100px]">検索</button>
-    </div>
+    <!-- 検索フォームのパーシャルを表示 -->
+    <%= render 'search_form', q: @q, url: beans_path %>
 
     <!-- 投稿カードを3列のグリッド形式で表示 -->
     <div class="grid grid-cols-3 gap-x-[80px] gap-y-[50px] my-[100px]">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
       update: 更新する
   defaults:
     delete_confirm: 削除してもよろしいですか？
+    search: 検索
   diagnoses:
     new:
       title: 豆診断
@@ -63,3 +64,6 @@ ja:
         store: 購入店舗名を入力（任意）
         taste_balance: 数値を選択（任意）
         comment: コメントを入力（必須）
+    search_form:
+      placeholder:
+        name_comment_country_name: 銘柄、コメント、生産国で探す


### PR DESCRIPTION
close #36 

## 概要
- 豆一覧ページにて、豆検索機能を実装した
- `Bean`モデルの`name`・`roast_level`・`comment`カラム、`Country`モデルの`name`カラムに対する検索が可能なように設定した

## 実施したタスク
- [x] `Gemfile`に`gem 'ransack'`を追記する
- [x] `docker compose run web bundle install`を実行する
- [x] `app/controllers/beans_controller.rb`の`index`アクションを編集する
- [x] `app/views/beans/_search_form.html.erb`（検索フォームのパーシャル）を作成する
- [x] 以下のモデルを編集し、`Ransack`の検索設定を行う
  - `app/models/bean.rb`
  - `app/models/country.rb`
- [x] `app/views/beans/index.html.erb`を編集し、検索フォームを追加する