### PR TITLE
お店の詳細情報確認ページの関連投稿表示タブを作成

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -4,7 +4,8 @@ class StoresController < ApplicationController
   end
 
   def show
-    @store = Store.includes(:beans).find(params[:id])
+    @store = Store.find(params[:id])
+    @beans = @store.beans
     @photo_reference = get_place_photo_reference(@store.place_id)
   end
 end

--- a/app/views/beans/show.html.erb
+++ b/app/views/beans/show.html.erb
@@ -84,25 +84,33 @@
         <p><%= @bean.comment %></p>
       </div>
 
-      <!-- 購入店舗の情報表示エリア -->
+      <!-- 購入店舗のマップ表示エリア -->
       <% if @bean.store.present? %>
-        <div class="text-left font-bold w-full">
-          <p><%= t('.store_information') %></p>
+        <!-- アイコンとラベル -->
+        <div class="flex justify-start items-center">
+          <i class="fa-solid fa-map-location text-[25px]"></i>
+          <p class="font-bold ml-2"><%= t('.store_map') %></p>
         </div>
-        <div class="relative text-sm w-full mb-[30px]">
+        <div class="relative text-sm w-full">
           <div class="absolute top-4 left-4 bg-white bg-opacity-80 p-4 w-1/2 z-10">
             <p class="font-bold mb-1"><%= @bean.store.name %></p>
             <p class="mb-2"><%= @bean.store.address %></p>
             <!-- Google Mapsへのリンク -->
             <div class="w-full">
               <!-- 'target: :_blank'：リンクをクリックした時に別タブで表示する -->
-              <%= link_to "https://www.google.com/maps/search/?api=1&query=#{@bean.store.name}&query_place_id=#{@bean.store.place_id}", target: :_blank, class: "block w-full text-center py-2 px-4 border border-primary bg-white rounded-sm" do %>
+              <%#= link_to "https://www.google.com/maps/search/?api=1&query=#{@bean.store.name}&query_place_id=#{@bean.store.place_id}", target: :_blank, class: "block w-full text-center py-2 px-4 border border-primary bg-white rounded-sm" do %>
+              <%= link_to "https://www.google.com/maps/dir/?api=1&destination=#{@bean.store.latitude},#{@bean.store.longitude}", target: :_blank, class: "block w-full text-center py-2 px-4 border border-primary bg-white rounded-sm" do %>
                 <%= t('.to_google_maps') %>
               <% end %>
             </div>
           </div>
           <!-- Google Maps表示エリア -->
           <div id="map" class="h-[400px] w-full rounded-sm"></div>
+        </div>
+
+        <!-- 店舗詳細ページへ遷移するボタン-->
+        <div class="text-center w-full mt-5 mb-7">
+          <%= link_to t('.to_store_detail'), store_path(@bean.store), class: "btn btn-accent w-[200px] h-[50px]" %>
         </div>
       <% end %>
     </div>

--- a/app/views/stores/_bean.html.erb
+++ b/app/views/stores/_bean.html.erb
@@ -1,0 +1,51 @@
+<div class="card bg-white w-full h-[400px] border-[2px] border-primary rounded-[10px] font-body">
+  <!-- 投稿画像を表示する部分 -->
+  <figure>
+    <%= image_tag bean.image_url, height: "200" %>
+  </figure>
+
+  <!-- 投稿内容を表示する部分 -->
+  <div class="card-body text-black shadow-md">
+    <!-- 銘柄を詳細ページへのリンクにする -->
+    <%= link_to bean_path(bean), data: { turbo: false } do%>
+      <h4 class="card-title truncate text-base font-bold link-primary underline mb-[10px]">
+        <%= bean.name %>
+      </h4>
+    <% end %>
+    <div class="space-y-[5px] text-left text-xs">
+      <p class="truncate">
+        <%= Country.human_attribute_name(:name) %>：<%= bean.country.name %>
+      </p>
+      <p class="truncate">
+        <%= Bean.human_attribute_name(:roast_level) %>：<%= bean.roast_level_i18n %>
+      </p>
+      <p class="line-clamp-2"><%= bean.comment %></p>
+    </div>
+
+    <div class="flex flex-row justify-between items-center mt-[20px]">
+      <!-- 投稿ユーザー情報表示エリア -->
+      <div class="flex flex-row items-center space-x-[5px]">
+        <div class="w-[40px] h-[40px] bg-neutral rounded-full"></div>
+        <div class="flex flex-col justify-center text-xs">
+          <p class="truncate"><%= bean.user.name %></p>
+          <p class="truncate"><%= bean.created_at.strftime("%Y/%m/%d") %></p>
+        </div>
+      </div>
+
+      <!-- 編集・削除アイコン表示エリア -->
+      <!-- ログインユーザーのidと投稿コンテンツのユーザーidが等しければ表示 -->
+      <% if user_signed_in? %>
+        <% if current_user.own?(bean) %>
+          <div class="flex flex-row items-center space-x-[15px] text-[20px]">
+            <%= link_to edit_bean_path(bean), data: { turbo: false } do %>
+              <i class="fa-solid fa-pen-to-square"></i>
+            <% end %>
+            <%= link_to bean_path(bean), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+              <i class="fa-solid fa-trash"></i>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -30,7 +30,7 @@
   <div role="tablist" class="tabs tabs-bordered grid grid-cols-2 w-full">
     <!-- 店舗の詳細情報タブ -->
     <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="<%= t('.tab_titles.store_detail') %>" checked="checked" />
-    <div role="tabpanel" class="tab-content border-black p-5 rounded-b-md shadow-lg">
+    <div role="tabpanel" class="tab-content border-primary p-5 rounded-b-md shadow-lg">
       <!-- 郵便番号表示エリア -->
       <div class="flex justify-start items-center mb-5">
         <i class="fa-solid fa-signs-post text-[25px]"></i>
@@ -96,8 +96,11 @@
 
     <!-- 関連投稿タブ -->
     <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="<%= t('.tab_titles.related_posts') %>" />
-    <div role="tabpanel" class="tab-content border-black p-5 rounded-b-md shadow-lg">
-      関連投稿をカード形式で表示
+    <div role="tabpanel" class="tab-content border-primary p-7 rounded-b-md shadow-lg">
+      <!-- 関連投稿を2列のグリッド形式で表示 -->
+      <div class="grid grid-cols-2 gap-5">
+        <%= render partial: 'bean', collection: @beans %>
+      </div>
     </div>
   </div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,8 +60,9 @@ ja:
     show:
       title: 豆詳細
       taste_balance: 味バランス
-      store_information: 購入店舗の情報
-      to_google_maps: Google Mapsで詳細を確認
+      store_map: マップ
+      to_google_maps: 現在地からの経路を確認
+      to_store_detail: 店舗の詳細情報を確認
       back_to_bean_index: 一覧へ戻る
     edit:
       title: 豆投稿編集


### PR DESCRIPTION
close #143 

## 概要
- 店舗詳細ページにて、「関連投稿」タブをクリックすると、関連投稿がカード形式で表示されるようにした
- 豆詳細ページから店舗詳細ページへのリンクを追加した

## 実施したタスク
- [x] `app/views/stores/show.html.erb`を編集する
- [x] 「関連投稿」のタブをクリックすると、関連投稿がそれぞれカード形式で表示される
- [x] 投稿カードの銘柄をクリックすると、豆詳細ページに遷移する
- [x] 投稿カードは豆一覧ページのものと同じとする
- [x] `app/views/beans/show.html.erb`を編集し、店舗詳細ページへのリンクを追加
- [x] `i18n`によるビューの日本語化