### PR TITLE
店舗一覧ページに店舗検索機能を追加

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -6,7 +6,7 @@ class StoresController < ApplicationController
 
   def show
     @store = Store.find(params[:id])
-    @beans = @store.beans
+    @beans = @store.beans.includes(:user, :country)
     @photo_reference = get_place_photo_reference(@store.place_id)
   end
 end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,6 +1,7 @@
 class StoresController < ApplicationController
   def index
-    @stores = Store.all
+    @q = Store.ransack(params[:q])
+    @stores = @q.result(distinct: true)
   end
 
   def show

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -2,4 +2,9 @@ class Store < ApplicationRecord
   validates :place_id, :name, :latitude, :longitude, presence: true, uniqueness: true
 
   has_many :beans
+
+  # Ransackが検索可能なカラムを設定
+  def self.ransackable_attributes(auth_object = nil)
+    ["name", "address"]
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -7,4 +7,9 @@ class Store < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["name", "address"]
   end
+
+  # Ransackが検索可能なアソシエーションを設定
+  def self.ransackable_associations(auth_object = nil)
+    ["beans"]
+  end
 end

--- a/app/views/stores/_search_form.html.erb
+++ b/app/views/stores/_search_form.html.erb
@@ -1,0 +1,11 @@
+<!-- Ransackを使用した検索フォーム -->
+<%= search_form_for q, url: url do |f| %>
+  <div class="flex flex-row justify-center items-center space-x-[20px] w-full h-[50px] my-5 mx-auto">
+    <!-- 店舗名と住所に対する検索フィールド（曖昧検索） -->
+    <div class="form-control">
+      <%= f.search_field :name_or_address_cont, class: "input input-bordered input-primary form-control bg-white w-[40rem] border-[3px] border-primary rounded-[10px]", placeholder: t('stores.search_form.placeholder.name_address') %>
+    </div>
+
+    <%= f.submit t('defaults.search'), class: "btn btn-accent w-[100px]" %>
+  </div>
+<% end %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -1,4 +1,7 @@
 <div class="flex flex-col w-full h-full mx-auto">
+  <!-- 検索フォームを表示 -->
+  <%= render 'search_form', q: @q, url: stores_path %>
+
   <!-- 地図を表示するための要素 -->
   <div id="map" class="w-full h-full"></div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -99,3 +99,6 @@ ja:
       to_google_maps: 現在地からの経路を確認
       google_maps: マップ
       back_to_store_index: 店舗一覧へ戻る
+    search_form:
+      placeholder:
+        name_address: 店舗名、住所で探す


### PR DESCRIPTION
close #96 

## 概要
- 店舗一覧ページにて、店舗名と住所で店舗を検索できる機能を追加した

## 実施したタスク
- [x] `app/controllers/stores_controller.rb`の`index`アクションを編集し、`Ransack`を使用した検索に対応させる
- [x] `app/views/stores/_search_form.html.erb`（検索フォームのパーシャル）を作成し、編集する
- [x] `app/models/store.rb`を編集し、`Ransack`の検索設定を行う
- [x] `app/views/stores/index.html.erb`を編集し、検索フォームのパーシャルを表示させる
- [x] `i18n`によるビューの日本語化